### PR TITLE
Refactor parser separation

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -3,34 +3,19 @@
 
 #include "common.h"
 #include "vm.h"
-#include "lexer.h"
 #include "ast.h"
 
-// Forward declarations
-typedef struct ASTNode ASTNode;
-
-// Compiler functions
 void initCompiler(Compiler* compiler, Chunk* chunk, const char* fileName, const char* source);
 uint8_t allocateRegister(Compiler* compiler);
 void freeRegister(Compiler* compiler, uint8_t reg);
 bool compile(ASTNode* ast, Compiler* compiler, bool isModule);
 
-// Code emission functions
 void emitByte(Compiler* compiler, uint8_t byte);
 void emitBytes(Compiler* compiler, uint8_t byte1, uint8_t byte2);
 void emitConstant(Compiler* compiler, uint8_t reg, Value value);
 
-// Simple parsing function for testing
-ASTNode* parseSource(const char* source);
-void freeAST(ASTNode* node);
+// Compilation helpers
+bool compileExpression(ASTNode* node, Compiler* compiler);
+int compileExpressionToRegister(ASTNode* node, Compiler* compiler);
 
-// Expression parsing functions
-ASTNode* parseExpression();
-ASTNode* parseBinaryExpression(int minPrec);
-ASTNode* parsePrimaryExpression();
-
-// Helper functions
-int getOperatorPrecedence(TokenType type);
-const char* getOperatorString(TokenType type);
-
-#endif
+#endif // COMPILER_H

--- a/include/parser.h
+++ b/include/parser.h
@@ -1,64 +1,11 @@
 #ifndef ORUS_PARSER_H
 #define ORUS_PARSER_H
 
+#include "vm.h"
 #include "lexer.h"
 #include "ast.h"
 
-// Simplified constraint system for parser
-typedef enum {
-    CONSTRAINT_NONE,
-    CONSTRAINT_NUMERIC,
-    CONSTRAINT_COMPARABLE
-} GenericConstraint;
+ASTNode* parseSource(const char* source);
+void freeAST(ASTNode* node);
 
-
-typedef enum {
-    PREC_NONE,
-    PREC_ASSIGNMENT,   // =
-    PREC_CONDITIONAL,  // ?:
-    PREC_OR,           // or
-    PREC_AND,          // and
-    PREC_BIT_OR,       // |
-    PREC_BIT_XOR,      // ^
-    PREC_BIT_AND,      // &
-    PREC_EQUALITY,     // == !=
-    PREC_COMPARISON,   // < > <= >=
-    PREC_SHIFT,        // << >>
-    PREC_TERM,         // + -
-    PREC_FACTOR,       // * /
-    PREC_UNARY,        // not -
-    PREC_CALL,         // . ()
-    PREC_PRIMARY
-} Precedence;
-
-typedef struct {
-    Token current;
-    Token previous;
-    bool hadError;
-    bool panicMode;
-    Lexer* lexer;
-    int functionDepth;      // Track nested function declarations
-    Type* currentImplType;  // Track struct type for methods
-    ObjString** genericParams;
-    GenericConstraint* genericConstraints;
-    int genericCount;
-    int genericCapacity;
-    const char* filePath;
-    int parenDepth;
-    bool inMatchCase;
-    bool doubleColonWarned;
-} Parser;
-
-typedef ASTNode* (*ParseFn)(Parser*);
-
-typedef struct {
-    ParseFn prefix;
-    ASTNode* (*infix)(Parser*, ASTNode* left);
-    Precedence precedence;
-} ParseRule;
-
-void initParser(Parser* parser, Lexer* lexer, const char* filePath);
-bool parse(const char* source, const char* filePath, ASTNode** ast);
-ParseRule* get_rule(TokenType type);
-
-#endif
+#endif // ORUS_PARSER_H

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ INCLUDES = -I$(INCDIR)
 
 # Source files
 CORE_SRCS =
-COMPILER_SRCS = $(SRCDIR)/compiler/compiler.c $(SRCDIR)/compiler/lexer.c
+COMPILER_SRCS = $(SRCDIR)/compiler/compiler.c $(SRCDIR)/compiler/lexer.c $(SRCDIR)/compiler/parser.c
 VM_SRCS = $(SRCDIR)/vm/vm.c
 MAIN_SRC = $(SRCDIR)/main.c
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1,394 +1,23 @@
-// Simple compiler implementation for testing
 #include "../../include/compiler.h"
 #include "../../include/common.h"
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-// Arena allocator for AST nodes (same as parser)
-typedef struct {
-    char* buffer;
-    size_t capacity, used;
-} Arena;
-
-static Arena compilerArena;
-
-static void arena_init(Arena* a, size_t initial) {
-    a->buffer = malloc(initial);
-    a->capacity = initial;
-    a->used = 0;
-}
-
-static void* arena_alloc(Arena* a, size_t size) {
-    if (a->used + size > a->capacity) {
-        size_t newCap = (a->capacity * 2) + size;
-        a->buffer = realloc(a->buffer, newCap);
-        a->capacity = newCap;
-    }
-    void* ptr = a->buffer + a->used;
-    a->used += size;
-    return ptr;
-}
-
-static void arena_reset(Arena* a) { a->used = 0; }
-
-static ASTNode* new_node(void) {
-    return arena_alloc(&compilerArena, sizeof(ASTNode));
-}
-
-static void addStatement(ASTNode*** list, int* count, int* capacity, ASTNode* stmt) {
-    if (*count + 1 > *capacity) {
-        int newCap = *capacity == 0 ? 4 : (*capacity * 2);
-        ASTNode** newArr = arena_alloc(&compilerArena, sizeof(ASTNode*) * newCap);
-        if (*capacity > 0) {
-            memcpy(newArr, *list, sizeof(ASTNode*) * (*count));
-        }
-        *list = newArr;
-        *capacity = newCap;
-    }
-    (*list)[(*count)++] = stmt;
-}
-
-// Simple token lookahead
-static Token peekedToken = {0};
-static bool hasPeekedToken = false;
-
-Token peekToken() {
-    if (!hasPeekedToken) {
-        peekedToken = scan_token();
-        hasPeekedToken = true;
-    }
-    return peekedToken;
-}
-
-Token nextToken() {
-    if (hasPeekedToken) {
-        hasPeekedToken = false;
-        return peekedToken;
-    }
-    return scan_token();
-}
-
-// Forward declarations
-ASTNode* parseExpression();
-ASTNode* parseBinaryExpression(int minPrec);
-ASTNode* parsePrimaryExpression();
-ASTNode* parseVariableDeclaration();
-static void addStatement(ASTNode*** list, int* count, int* capacity, ASTNode* stmt);
-
-// Real parsing function using lexer
-ASTNode* parseSource(const char* source) {
-    arena_init(&compilerArena, 1 << 16);
-    init_scanner(source);
-    hasPeekedToken = false;
-
-    ASTNode** statements = NULL;
-    int count = 0;
-    int capacity = 0;
-
-    while (true) {
-        Token t = peekToken();
-        if (t.type == TOKEN_EOF) break;
-        if (t.type == TOKEN_NEWLINE || t.type == TOKEN_SEMICOLON) {
-            nextToken();
-            continue;
-        }
-
-        ASTNode* stmt = NULL;
-        if (t.type == TOKEN_LET) {
-            stmt = parseVariableDeclaration();
-        } else {
-            stmt = parseExpression();
-        }
-        if (!stmt) return NULL;
-
-        addStatement(&statements, &count, &capacity, stmt);
-
-        t = peekToken();
-        if (t.type == TOKEN_SEMICOLON || t.type == TOKEN_NEWLINE) {
-            nextToken();
-        }
-    }
-
-    ASTNode* program = new_node();
-    program->type = NODE_PROGRAM;
-    program->program.declarations = statements;
-    program->program.count = count;
-    program->location.line = 1;
-    program->location.column = 1;
-    program->dataType = NULL;
-    return program;
-}
-
-// Parse variable declarations: let name = initializer
-ASTNode* parseVariableDeclaration() {
-    Token letToken = nextToken(); // consume 'let'
-    if (letToken.type != TOKEN_LET) {
-        return NULL; // Error
-    }
-    
-    Token nameToken = nextToken();
-    if (nameToken.type != TOKEN_IDENTIFIER) {
-        return NULL; // Error: expected identifier
-    }
-    
-    ASTNode* typeNode = NULL;
-    if (peekToken().type == TOKEN_COLON) {
-        nextToken();
-        Token typeTok = nextToken();
-        if (typeTok.type != TOKEN_IDENTIFIER && typeTok.type != TOKEN_INT &&
-            typeTok.type != TOKEN_I64 && typeTok.type != TOKEN_U32 &&
-            typeTok.type != TOKEN_U64 && typeTok.type != TOKEN_F64 &&
-            typeTok.type != TOKEN_BOOL) {
-            return NULL;
-        }
-        int tl = typeTok.length;
-        char* typeName = arena_alloc(&compilerArena, tl + 1);
-        strncpy(typeName, typeTok.start, tl);
-        typeName[tl] = '\0';
-        typeNode = new_node();
-        typeNode->type = NODE_TYPE;
-        typeNode->typeAnnotation.name = typeName;
-    }
-
-    Token equalToken = nextToken();
-    if (equalToken.type != TOKEN_EQUAL) {
-        return NULL; // Error: expected '='
-    }
-    
-    ASTNode* initializer = parseExpression();
-    if (!initializer) {
-        return NULL; // Error parsing initializer
-    }
-    
-    // Create variable declaration node
-    ASTNode* varNode = new_node();
-    
-    varNode->type = NODE_VAR_DECL;
-    varNode->location.line = letToken.line;
-    varNode->location.column = letToken.column;
-    varNode->dataType = NULL;
-    
-    // Copy variable name
-    int len = nameToken.length;
-    char* name = arena_alloc(&compilerArena, len + 1);
-    strncpy(name, nameToken.start, len);
-    name[len] = '\0';
-    
-    varNode->varDecl.name = name;
-    varNode->varDecl.isPublic = false;
-    varNode->varDecl.initializer = initializer;
-    varNode->varDecl.typeAnnotation = typeNode;
-    varNode->varDecl.isConst = false;
-    
-    return varNode;
-}
-
-// Parse expressions with operator precedence
-ASTNode* parseExpression() {
-    return parseBinaryExpression(0);
-}
-
-// Parse binary expressions with precedence climbing
-ASTNode* parseBinaryExpression(int minPrec) {
-    ASTNode* left = parsePrimaryExpression();
-    if (!left) return NULL;
-    
-    while (true) {
-        Token operator = peekToken();
-        int prec = getOperatorPrecedence(operator.type);
-        
-        if (prec < minPrec || operator.type == TOKEN_EOF) {
-            break;
-        }
-        
-        // Consume the operator token
-        nextToken();
-        
-        ASTNode* right = parseBinaryExpression(prec + 1);
-        if (!right) return NULL;
-        
-        // Create binary expression node
-        ASTNode* binaryNode = new_node();
-        
-        binaryNode->type = NODE_BINARY;
-        binaryNode->binary.left = left;
-        binaryNode->binary.right = right;
-        binaryNode->binary.op = (char*)getOperatorString(operator.type);
-        binaryNode->location.line = operator.line;
-        binaryNode->location.column = operator.column;
-        binaryNode->dataType = NULL;
-        
-        left = binaryNode;
-    }
-    
-    return left;
-}
-
-// Parse primary expressions (numbers, strings, variables, parentheses)
-ASTNode* parsePrimaryExpression() {
-    Token token = nextToken();
-    
-    switch (token.type) {
-        case TOKEN_NUMBER: {
-            ASTNode* node = new_node();
-            node->type = NODE_LITERAL;
-            
-            // Parse the number from token
-            char numStr[32];
-            int len = token.length < 31 ? token.length : 31;
-            strncpy(numStr, token.start, len);
-            numStr[len] = '\0';
-            
-            node->literal.value = I32_VAL(atoi(numStr));
-            node->location.line = token.line;
-            node->location.column = token.column;
-            node->dataType = NULL;
-            return node;
-        }
-        
-        case TOKEN_STRING: {
-            ASTNode* node = new_node();
-            node->type = NODE_LITERAL;
-            
-            // Extract string content (remove quotes)
-            int contentLen = token.length - 2; // Remove quotes
-            char* content = malloc(contentLen + 1);
-            strncpy(content, token.start + 1, contentLen);
-            content[contentLen] = '\0';
-            
-            // Create string object - for now use a simple approach
-            // Create a string value - we'll fix this when the value system is unified
-            node->literal.value = I32_VAL(0); // Placeholder until string values work
-            
-            free(content);
-            node->location.line = token.line;
-            node->location.column = token.column;
-            node->dataType = NULL;
-            return node;
-        }
-        
-        case TOKEN_TRUE: {
-            ASTNode* node = new_node();
-            node->type = NODE_LITERAL;
-            node->literal.value = BOOL_VAL(true);
-            node->location.line = token.line;
-            node->location.column = token.column;
-            node->dataType = NULL;
-            return node;
-        }
-        
-        case TOKEN_FALSE: {
-            ASTNode* node = new_node();
-            node->type = NODE_LITERAL;
-            node->literal.value = BOOL_VAL(false);
-            node->location.line = token.line;
-            node->location.column = token.column;
-            node->dataType = NULL;
-            return node;
-        }
-        
-        case TOKEN_IDENTIFIER: {
-            ASTNode* node = new_node();
-            node->type = NODE_IDENTIFIER;
-            
-            // Copy identifier name
-            int len = token.length;
-            char* name = arena_alloc(&compilerArena, len + 1);
-            strncpy(name, token.start, len);
-            name[len] = '\0';
-            
-            node->identifier.name = name;
-            node->location.line = token.line;
-            node->location.column = token.column;
-            node->dataType = NULL;
-            return node;
-        }
-        
-        case TOKEN_LEFT_PAREN: {
-            ASTNode* expr = parseExpression();
-            Token closeParen = nextToken();
-            if (closeParen.type != TOKEN_RIGHT_PAREN) {
-                // Error: expected ')'
-                return NULL;
-            }
-            return expr;
-        }
-        
-        default:
-            // Error: unexpected token
-            return NULL;
-    }
-}
-
-// Helper functions
-int getOperatorPrecedence(TokenType type) {
-    switch (type) {
-        case TOKEN_PLUS:
-        case TOKEN_MINUS:
-            return 1;
-        case TOKEN_STAR:
-        case TOKEN_SLASH:
-        case TOKEN_MODULO:
-            return 2;
-        case TOKEN_EQUAL_EQUAL:
-        case TOKEN_BANG_EQUAL:
-            return 0;
-        case TOKEN_LESS:
-        case TOKEN_GREATER:
-        case TOKEN_LESS_EQUAL:
-        case TOKEN_GREATER_EQUAL:
-            return 0;
-        default:
-            return -1;
-    }
-}
-
-const char* getOperatorString(TokenType type) {
-    switch (type) {
-        case TOKEN_PLUS: return "+";
-        case TOKEN_MINUS: return "-";
-        case TOKEN_STAR: return "*";
-        case TOKEN_SLASH: return "/";
-        case TOKEN_MODULO: return "%";
-        case TOKEN_EQUAL_EQUAL: return "==";
-        case TOKEN_BANG_EQUAL: return "!=";
-        case TOKEN_LESS: return "<";
-        case TOKEN_GREATER: return ">";
-        case TOKEN_LESS_EQUAL: return "<=";
-        case TOKEN_GREATER_EQUAL: return ">=";
-        default: return "?";
-    }
-}
-
-void freeAST(ASTNode* node) {
-    // Using arena allocation - just reset the arena
-    arena_reset(&compilerArena);
-    (void)node;
-}
-
-// Enhanced compilation function - converts expressions to bytecode
+// Convert an expression AST to a register and emit bytecode
 int compileExpressionToRegister(ASTNode* node, Compiler* compiler) {
     if (!node) return -1;
-    
+
     switch (node->type) {
         case NODE_LITERAL: {
             uint8_t reg = allocateRegister(compiler);
             emitConstant(compiler, reg, node->literal.value);
             return reg;
         }
-        
         case NODE_BINARY: {
-            // Compile left and right operands
             int leftReg = compileExpressionToRegister(node->binary.left, compiler);
             if (leftReg < 0) return -1;
-            
             int rightReg = compileExpressionToRegister(node->binary.right, compiler);
             if (rightReg < 0) return -1;
-            
             uint8_t resultReg = allocateRegister(compiler);
-            
-            // Generate appropriate instruction based on operator
             const char* op = node->binary.op;
             if (strcmp(op, "+") == 0) {
                 emitByte(compiler, OP_ADD_I32_R);
@@ -405,57 +34,42 @@ int compileExpressionToRegister(ASTNode* node, Compiler* compiler) {
             } else if (strcmp(op, "<") == 0) {
                 emitByte(compiler, OP_LT_I32_R);
             } else {
-                return -1; // Unsupported operator
+                return -1;
             }
-            
-            // Emit operand registers
             emitByte(compiler, resultReg);
             emitByte(compiler, (uint8_t)leftReg);
             emitByte(compiler, (uint8_t)rightReg);
-            
             return resultReg;
         }
-        
         case NODE_IDENTIFIER: {
-            // Look up variable in locals
             const char* name = node->identifier.name;
             for (int i = compiler->localCount - 1; i >= 0; i--) {
-                if (compiler->locals[i].isActive && 
+                if (compiler->locals[i].isActive &&
                     strcmp(compiler->locals[i].name, name) == 0) {
                     return compiler->locals[i].reg;
                 }
             }
-            
-            // Variable not found - return 0 for now
             uint8_t reg = allocateRegister(compiler);
             emitConstant(compiler, reg, I32_VAL(0));
             return reg;
         }
-        
         case NODE_VAR_DECL: {
-            // Compile the initializer
             int initReg = compileExpressionToRegister(node->varDecl.initializer, compiler);
             if (initReg < 0) return -1;
-            
-            // Add variable to locals table
             if (compiler->localCount >= REGISTER_COUNT) {
-                return -1; // Too many locals
+                return -1;
             }
-            
             int localIndex = compiler->localCount++;
             compiler->locals[localIndex].name = node->varDecl.name;
             compiler->locals[localIndex].reg = (uint8_t)initReg;
             compiler->locals[localIndex].isActive = true;
-            
             return initReg;
         }
-        
         default:
             return -1;
     }
 }
 
-// Wrapper function to maintain compatibility
 bool compileExpression(ASTNode* node, Compiler* compiler) {
     return compileExpressionToRegister(node, compiler) >= 0;
 }

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -1,33 +1,22 @@
-/* parser.c
- * 10× faster, production-ready Orus parser with arena allocator,
- * inline helpers, batched skipping, two-token lookahead,
- * and improved error synchronization.
- */
-
 #include "../../include/parser.h"
-
+#include "../../include/common.h"
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
-#include "../../include/common.h"
-#include "../../include/type.h"
-
-// -----------------------------------------------------------------------------
-// Arena Allocator for AST nodes, strings, diagnostics
-// -----------------------------------------------------------------------------
+// Simple arena allocator used for AST nodes
 typedef struct {
     char* buffer;
     size_t capacity, used;
 } Arena;
 
-static Arena arena;
+static Arena parserArena;
 
 static void arena_init(Arena* a, size_t initial) {
     a->buffer = malloc(initial);
     a->capacity = initial;
     a->used = 0;
 }
+
 static void* arena_alloc(Arena* a, size_t size) {
     if (a->used + size > a->capacity) {
         size_t newCap = (a->capacity * 2) + size;
@@ -38,223 +27,305 @@ static void* arena_alloc(Arena* a, size_t size) {
     a->used += size;
     return ptr;
 }
+
 static void arena_reset(Arena* a) { a->used = 0; }
 
-// -----------------------------------------------------------------------------
-// Parser initialization (replaces manual struct zeroing)
-// -----------------------------------------------------------------------------
-static void initParser(Parser* parser, const char* filePath) {
-    memset(parser, 0, sizeof(*parser));
-    parser->hadError = false;
-    parser->panicMode = false;
-    parser->filePath = filePath;
-    parser->functionDepth = 0;
-    parser->currentImplType = NULL;
-    parser->genericParams = NULL;
-    parser->genericConstraints = NULL;
-    parser->genericCount = 0;
-    parser->genericCapacity = 0;
-    parser->parenDepth = 0;
-    parser->inMatchCase = false;
-    parser->doubleColonWarned = false;
-}
+static ASTNode* new_node(void) { return arena_alloc(&parserArena, sizeof(ASTNode)); }
 
-// -----------------------------------------------------------------------------
-// Profiling (optional)
-// -----------------------------------------------------------------------------
-static inline long now_ns(void) {
-    struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return ts.tv_sec * 1000000000L + ts.tv_nsec;
-}
-
-// -----------------------------------------------------------------------------
-// Two-token lookahead buffer
-// -----------------------------------------------------------------------------
-static Token lookahead[2];
-static int laCount;
-static Parser* P;
-
-static void fill_lookahead(void) {
-    while (laCount < 2) {
-        lookahead[laCount++] = scan_token();
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Inline helper functions
-// -----------------------------------------------------------------------------
-static inline void advance_(void) {
-    P->previous = P->current;
-    if (laCount > 0) {
-        P->current = lookahead[--laCount];
-    } else {
-        P->current = scan_token();
-    }
-}
-static inline bool check_(TokenType t) { return P->current.type == t; }
-static inline bool match_(TokenType t) {
-    if (!check_(t)) return false;
-    advance_();
-    return true;
-}
-static inline void skipNonCodeTokens(void) {
-    while (true) {
-        TokenType t = P->current.type;
-        if (t == TOKEN_NEWLINE || t == TOKEN_SEMICOLON ||
-            t == TOKEN_WHITESPACE) {
-            advance_();
-        } else if (t == TOKEN_COMMENT) {
-            advance_();
-        } else
-            break;
-    }
-}
-
-// -----------------------------------------------------------------------------
-// Error synchronization set
-// -----------------------------------------------------------------------------
-static const TokenType syncSet[] = {TOKEN_IF,  TOKEN_WHILE,  TOKEN_FOR,
-                                    TOKEN_FN,  TOKEN_RETURN, TOKEN_STRUCT,
-                                    TOKEN_EOF, TOKEN_NEWLINE};
-static inline void synchronize_(void) {
-    P->panicMode = false;
-    while (P->current.type != TOKEN_EOF) {
-        for (size_t i = 0; i < sizeof(syncSet) / sizeof(*syncSet); i++) {
-            if (P->current.type == syncSet[i]) return;
+static void addStatement(ASTNode*** list, int* count, int* capacity, ASTNode* stmt) {
+    if (*count + 1 > *capacity) {
+        int newCap = *capacity == 0 ? 4 : (*capacity * 2);
+        ASTNode** newArr = arena_alloc(&parserArena, sizeof(ASTNode*) * newCap);
+        if (*capacity > 0) {
+            memcpy(newArr, *list, sizeof(ASTNode*) * (*count));
         }
-        advance_();
+        *list = newArr;
+        *capacity = newCap;
+    }
+    (*list)[(*count)++] = stmt;
+}
+
+// Simple token lookahead
+static Token peekedToken;
+static bool hasPeekedToken = false;
+
+static Token peekToken(void) {
+    if (!hasPeekedToken) {
+        peekedToken = scan_token();
+        hasPeekedToken = true;
+    }
+    return peekedToken;
+}
+
+static Token nextToken(void) {
+    if (hasPeekedToken) {
+        hasPeekedToken = false;
+        return peekedToken;
+    }
+    return scan_token();
+}
+
+// Forward declarations
+static ASTNode* parseExpression(void);
+static ASTNode* parseBinaryExpression(int minPrec);
+static ASTNode* parsePrimaryExpression(void);
+static ASTNode* parseVariableDeclaration(void);
+
+static int getOperatorPrecedence(TokenType type) {
+    switch (type) {
+        case TOKEN_PLUS:
+        case TOKEN_MINUS:
+            return 1;
+        case TOKEN_STAR:
+        case TOKEN_SLASH:
+        case TOKEN_MODULO:
+            return 2;
+        case TOKEN_EQUAL_EQUAL:
+        case TOKEN_BANG_EQUAL:
+            return 0;
+        case TOKEN_LESS:
+        case TOKEN_GREATER:
+        case TOKEN_LESS_EQUAL:
+        case TOKEN_GREATER_EQUAL:
+            return 0;
+        default:
+            return -1;
     }
 }
 
-// -----------------------------------------------------------------------------
-// Helper to allocate AST nodes
-// -----------------------------------------------------------------------------
-static inline ASTNode* new_node(void) {
-    return arena_alloc(&arena, sizeof(ASTNode));
+static const char* getOperatorString(TokenType type) {
+    switch (type) {
+        case TOKEN_PLUS: return "+";
+        case TOKEN_MINUS: return "-";
+        case TOKEN_STAR: return "*";
+        case TOKEN_SLASH: return "/";
+        case TOKEN_MODULO: return "%";
+        case TOKEN_EQUAL_EQUAL: return "==";
+        case TOKEN_BANG_EQUAL: return "!=";
+        case TOKEN_LESS: return "<";
+        case TOKEN_GREATER: return ">";
+        case TOKEN_LESS_EQUAL: return "<=";
+        case TOKEN_GREATER_EQUAL: return ">=";
+        default: return "?";
+    }
 }
 
-// -----------------------------------------------------------------------------
-// Pratt parser core
-// -----------------------------------------------------------------------------
-static inline ParseRule* rule_(TokenType t) { return &rules[t]; }
-static ASTNode* parse_precedence(Precedence prec);
-static ASTNode* parse_expression(void) {
-    return parse_precedence(PREC_ASSIGNMENT);
+ASTNode* parseSource(const char* source) {
+    arena_init(&parserArena, 1 << 16);
+    init_scanner(source);
+    hasPeekedToken = false;
+
+    ASTNode** statements = NULL;
+    int count = 0;
+    int capacity = 0;
+
+    while (true) {
+        Token t = peekToken();
+        if (t.type == TOKEN_EOF) break;
+        if (t.type == TOKEN_NEWLINE || t.type == TOKEN_SEMICOLON) {
+            nextToken();
+            continue;
+        }
+
+        ASTNode* stmt = NULL;
+        if (t.type == TOKEN_LET) {
+            stmt = parseVariableDeclaration();
+        } else {
+            stmt = parseExpression();
+        }
+        if (!stmt) return NULL;
+
+        addStatement(&statements, &count, &capacity, stmt);
+
+        t = peekToken();
+        if (t.type == TOKEN_SEMICOLON || t.type == TOKEN_NEWLINE) {
+            nextToken();
+        }
+    }
+
+    ASTNode* program = new_node();
+    program->type = NODE_PROGRAM;
+    program->program.declarations = statements;
+    program->program.count = count;
+    program->location.line = 1;
+    program->location.column = 1;
+    program->dataType = NULL;
+    return program;
 }
-static ASTNode* parse_precedence(Precedence prec) {
-    skipNonCodeTokens();
-    advance_();
-    if (P->current.type == TOKEN_EOF) {
-        error(P, "Unexpected end of file.");
+
+static ASTNode* parseVariableDeclaration(void) {
+    Token letToken = nextToken();
+    if (letToken.type != TOKEN_LET) {
         return NULL;
     }
-    ParseFn prefix = rule_(P->previous.type)->prefix;
-    if (!prefix) {
-        error(P, "Expected expression.");
+
+    Token nameToken = nextToken();
+    if (nameToken.type != TOKEN_IDENTIFIER) {
         return NULL;
     }
-    ASTNode* left = prefix(P);
-    while (!P->hadError && prec <= rule_(P->current.type)->precedence) {
-        advance_();
-        ParseFn infix = rule_(P->previous.type)->infix;
-        left = infix(P, left);
+
+    ASTNode* typeNode = NULL;
+    if (peekToken().type == TOKEN_COLON) {
+        nextToken();
+        Token typeTok = nextToken();
+        if (typeTok.type != TOKEN_IDENTIFIER && typeTok.type != TOKEN_INT &&
+            typeTok.type != TOKEN_I64 && typeTok.type != TOKEN_U32 &&
+            typeTok.type != TOKEN_U64 && typeTok.type != TOKEN_F64 &&
+            typeTok.type != TOKEN_BOOL) {
+            return NULL;
+        }
+        int tl = typeTok.length;
+        char* typeName = arena_alloc(&parserArena, tl + 1);
+        strncpy(typeName, typeTok.start, tl);
+        typeName[tl] = '\0';
+        typeNode = new_node();
+        typeNode->type = NODE_TYPE;
+        typeNode->typeAnnotation.name = typeName;
     }
+
+    Token equalToken = nextToken();
+    if (equalToken.type != TOKEN_EQUAL) {
+        return NULL;
+    }
+
+    ASTNode* initializer = parseExpression();
+    if (!initializer) {
+        return NULL;
+    }
+
+    ASTNode* varNode = new_node();
+    varNode->type = NODE_VAR_DECL;
+    varNode->location.line = letToken.line;
+    varNode->location.column = letToken.column;
+    varNode->dataType = NULL;
+
+    int len = nameToken.length;
+    char* name = arena_alloc(&parserArena, len + 1);
+    strncpy(name, nameToken.start, len);
+    name[len] = '\0';
+
+    varNode->varDecl.name = name;
+    varNode->varDecl.isPublic = false;
+    varNode->varDecl.initializer = initializer;
+    varNode->varDecl.typeAnnotation = typeNode;
+    varNode->varDecl.isConst = false;
+
+    return varNode;
+}
+
+static ASTNode* parseExpression(void) {
+    return parseBinaryExpression(0);
+}
+
+static ASTNode* parseBinaryExpression(int minPrec) {
+    ASTNode* left = parsePrimaryExpression();
+    if (!left) return NULL;
+
+    while (true) {
+        Token operator = peekToken();
+        int prec = getOperatorPrecedence(operator.type);
+
+        if (prec < minPrec || operator.type == TOKEN_EOF) {
+            break;
+        }
+
+        nextToken();
+
+        ASTNode* right = parseBinaryExpression(prec + 1);
+        if (!right) return NULL;
+
+        ASTNode* binaryNode = new_node();
+        binaryNode->type = NODE_BINARY;
+        binaryNode->binary.left = left;
+        binaryNode->binary.right = right;
+        binaryNode->binary.op = (char*)getOperatorString(operator.type);
+        binaryNode->location.line = operator.line;
+        binaryNode->location.column = operator.column;
+        binaryNode->dataType = NULL;
+
+        left = binaryNode;
+    }
+
     return left;
 }
 
-// -----------------------------------------------------------------------------
-// Example refactored parse functions
-// -----------------------------------------------------------------------------
-static ASTNode* parseString(Parser* parser) {
-    const char* start = parser->previous.start + 1;
-    int length = parser->previous.length - 2;
-    char* buf = arena_alloc(&arena, length + 1);
-    int out = 0;
-    for (int i = 0; i < length; i++) {
-        char c = start[i];
-        if (c == '\\') {
-            i++;
-            c = start[i] == 'n'    ? '\n'
-                : start[i] == 't'  ? '\t'
-                : start[i] == '\\' ? '\\'
-                : start[i] == '"'  ? '"'
-                                   : start[i];
+static ASTNode* parsePrimaryExpression(void) {
+    Token token = nextToken();
+
+    switch (token.type) {
+        case TOKEN_NUMBER: {
+            ASTNode* node = new_node();
+            node->type = NODE_LITERAL;
+            char numStr[32];
+            int len = token.length < 31 ? token.length : 31;
+            strncpy(numStr, token.start, len);
+            numStr[len] = '\0';
+            node->literal.value = I32_VAL(atoi(numStr));
+            node->location.line = token.line;
+            node->location.column = token.column;
+            node->dataType = NULL;
+            return node;
         }
-        buf[out++] = c;
-    }
-    buf[out] = '\0';
-    ObjString* str = allocateString(buf, out);
-    ASTNode* n = new_node();
-    *n = (ASTNode){.type = AST_LITERAL,
-                   .value = STRING_VAL(str),
-                   .valueType = createPrimitiveType(TYPE_STRING),
-                   .line = parser->previous.line};
-    return n;
-}
-static ASTNode* parseNumber(Parser* parser) {
-    char* raw = arena_alloc(&arena, parser->previous.length + 1);
-    memcpy(raw, parser->previous.start, parser->previous.length);
-    raw[parser->previous.length] = '\0';
-    bool isFloat = strchr(raw, '.') || strchr(raw, 'e') || strchr(raw, 'E');
-    ASTNode* n = new_node();
-    if (isFloat) {
-        double v = strtod(raw, NULL);
-        *n = (ASTNode){.type = AST_LITERAL,
-                       .value = F64_VAL(v),
-                       .valueType = createPrimitiveType(TYPE_F64),
-                       .line = parser->previous.line};
-    } else {
-        unsigned long long u = strtoull(raw, NULL, 0);
-        *n = (ASTNode){.type = AST_LITERAL,
-                       .value = U64_VAL(u),
-                       .valueType = createPrimitiveType(TYPE_U64),
-                       .line = parser->previous.line};
-    }
-    return n;
-}
-static ASTNode* parseGrouping(Parser* parser) {
-    ASTNode* expr = parse_precedence(PREC_ASSIGNMENT);
-    consume(parser, TOKEN_RIGHT_PAREN, "Expect ')' after expression.");
-    return expr;
-}
-
-// -----------------------------------------------------------------------------
-// Entry point
-// -----------------------------------------------------------------------------
-bool parse(const char* source, const char* filePath, ASTNode** outAst) {
-    long t0 = now_ns();
-    arena_init(&arena, 1 << 16);
-    Parser parser;
-    initParser(&parser, filePath);
-    P = &parser;
-    init_scanner(source);
-    laCount = 0;
-    fill_lookahead();
-    advance_();
-
-    ASTNode *head = NULL, *tail = NULL;
-    while (P->current.type != TOKEN_EOF) {
-        skipNonCodeTokens();
-        ASTNode* stmt = parseStatement(&parser);  // implement parseStatement
-        if (stmt) {
-            if (!head)
-                head = stmt;
-            else
-                tail->next = stmt;
-            tail = stmt;
+        case TOKEN_STRING: {
+            ASTNode* node = new_node();
+            node->type = NODE_LITERAL;
+            int contentLen = token.length - 2;
+            char* content = malloc(contentLen + 1);
+            strncpy(content, token.start + 1, contentLen);
+            content[contentLen] = '\0';
+            node->literal.value = I32_VAL(0);
+            free(content);
+            node->location.line = token.line;
+            node->location.column = token.column;
+            node->dataType = NULL;
+            return node;
         }
-        if (parser.hadError) synchronize_();
+        case TOKEN_TRUE: {
+            ASTNode* node = new_node();
+            node->type = NODE_LITERAL;
+            node->literal.value = BOOL_VAL(true);
+            node->location.line = token.line;
+            node->location.column = token.column;
+            node->dataType = NULL;
+            return node;
+        }
+        case TOKEN_FALSE: {
+            ASTNode* node = new_node();
+            node->type = NODE_LITERAL;
+            node->literal.value = BOOL_VAL(false);
+            node->location.line = token.line;
+            node->location.column = token.column;
+            node->dataType = NULL;
+            return node;
+        }
+        case TOKEN_IDENTIFIER: {
+            ASTNode* node = new_node();
+            node->type = NODE_IDENTIFIER;
+            int len = token.length;
+            char* name = arena_alloc(&parserArena, len + 1);
+            strncpy(name, token.start, len);
+            name[len] = '\0';
+            node->identifier.name = name;
+            node->location.line = token.line;
+            node->location.column = token.column;
+            node->dataType = NULL;
+            return node;
+        }
+        case TOKEN_LEFT_PAREN: {
+            ASTNode* expr = parseExpression();
+            Token closeParen = nextToken();
+            if (closeParen.type != TOKEN_RIGHT_PAREN) {
+                return NULL;
+            }
+            return expr;
+        }
+        default:
+            return NULL;
     }
-    *outAst = head;
-    long t1 = now_ns();
-    fprintf(stderr, "Parsed in %.3f ms\n", (t1 - t0) / 1e6);
-    arena_reset(&arena);
-    return !parser.hadError;
 }
 
-// -----------------------------------------------------------------------------
-// Parse rule table (unchanged, but rule_ is cached)
-// -----------------------------------------------------------------------------
-ParseRule rules[] = {/* ... same as before ... */};
-ParseRule* get_rule(TokenType t) { return &rules[t]; }
+void freeAST(ASTNode* node) {
+    arena_reset(&parserArena);
+    (void)node;
+}
+

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -6,6 +6,7 @@
 #include "vm.h"
 #include "common.h"
 #include "compiler.h"
+#include "parser.h"
 
 // Global VM instance
 VM vm;


### PR DESCRIPTION
## Summary
- move parsing logic from `compiler.c` into new standalone `parser.c`
- trim `compiler.c` to only compilation helpers
- expose parsing API in `parser.h`
- adjust build system and includes for new parser module