### PR TITLE
Fix constant index overflow and arena memory

### DIFF
--- a/src/vm/debug.c
+++ b/src/vm/debug.c
@@ -24,11 +24,11 @@ int disassembleInstruction(Chunk* chunk, int offset) {
     switch (instruction) {
         case OP_LOAD_CONST: {
             uint8_t reg = chunk->code[offset + 1];
-            uint8_t constant = chunk->code[offset + 2];
+            uint16_t constant = (uint16_t)((chunk->code[offset + 2] << 8) | chunk->code[offset + 3]);
             printf("%-16s R%d, #%d '", "LOAD_CONST", reg, constant);
             printValue(chunk->constants.values[constant]);
             printf("'\n");
-            return offset + 3;
+            return offset + 4;
         }
 
         case OP_LOAD_NIL: {

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -287,7 +287,7 @@ static InterpretResult run(void) {
 
 LABEL_OP_LOAD_CONST: {
         uint8_t reg = READ_BYTE();
-        uint8_t constantIndex = READ_BYTE();
+        uint16_t constantIndex = READ_SHORT();
         vm.registers[reg] = READ_CONSTANT(constantIndex);
         DISPATCH();
     }
@@ -589,7 +589,7 @@ LABEL_UNKNOWN:
         switch (instruction) {
             case OP_LOAD_CONST: {
                 uint8_t reg = READ_BYTE();
-                uint8_t constantIndex = READ_BYTE();
+                uint16_t constantIndex = READ_SHORT();
                 vm.registers[reg] = READ_CONSTANT(constantIndex);
                 break;
             }


### PR DESCRIPTION
## Summary
- stabilize parser arena to avoid pointer invalidation
- support more than 255 constants with 16-bit indexes
- update VM and debugger for new constant format
- use temporary register reuse in compiler

## Testing
- `make test`
- `./orus benchmarks/test_150_ops_fixed.orus | tail -n 1`
- `./orus benchmarks/test_500_ops_fixed.orus | tail -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6861517cd28c8325b7f8d5d7b60f1321