### PR TITLE
Enable indent tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Execute code from a file.
 ```
 Shows register states and instruction execution.
 
+### 5. Indentation-Based Syntax
+The lexer supports `INDENT` and `DEDENT` tokens, preparing Orus for the new
+colon-driven syntax outlined in [LANGUAGE.md](docs/LANGUAGE.md).
+
 ## Build Instructions
 
 ```bash

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -96,6 +96,8 @@ typedef enum {
     TOKEN_NEWLINE,
 
     TOKEN_COLON,  // Add this for type annotations
+    TOKEN_INDENT,
+    TOKEN_DEDENT,
 } TokenType;
 
 typedef struct {
@@ -115,6 +117,10 @@ typedef struct {
     const char* lineStart;  // Track start of current line for precise column
                             // calculation
     bool inBlockComment;    // Track whether we are inside a block comment
+    int indentStack[64];
+    int indentTop;
+    int pendingDedents;
+    bool atLineStart;
 } Lexer;
 
 typedef struct {


### PR DESCRIPTION
## Summary
- add INDENT/DEDENT tokens and tracking fields in the lexer
- emit INDENT/DEDENT/NEWLINE tokens based on indentation
- mention the new indentation based syntax in the README

## Testing
- `make clean && make`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861749ae0d48325948f424358586ed6