### PR TITLE
Implement mutable variables and compound assignment

### DIFF
--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -161,6 +161,11 @@ static void compileStringConcat(Compiler* compiler, ASTNode* left, ASTNode* righ
 
 ### 1.2 Variable Assignment Implementation
 
+Variables can be declared immutable with `let` or mutable using `let mut`. Type
+annotations are parsed after a colon and stored on the AST for future type
+checking. The compiler records mutability in its local table to prevent writes
+to immutable bindings.
+
 #### Enhanced Symbol Table
 ```c
 // Symbol table with proper scoping and mutability
@@ -269,6 +274,11 @@ static void compileAssignment(Compiler* compiler, ASTNode* node) {
     freeRegister(compiler, value_reg);
 }
 ```
+
+Compound assignment operators such as `+=` or `*=` are translated in the parser
+into a `NODE_BINARY` expression combined with a normal assignment. This keeps the
+code generation simple while still emitting the optimized arithmetic opcodes
+shown above.
 
 ### 1.3 Boolean and Comparison Operations
 

--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -107,9 +107,9 @@ print("Array has {} items", len(items))
 
 **Features to Implement:**
 - [x] `x = value` syntax parsing
-- [ ] Mutable vs immutable variables (`let mut x = 42`)
-- [ ] Compound assignments (`+=`, `-=`, `*=`, `/=`)
-- [ ] Type annotations (`let x: i32 = 42`)
+- [x] Mutable vs immutable variables (`let mut x = 42`)
+- [x] Compound assignments (`+=`, `-=`, `*=`, `/=`)
+- [x] Type annotations (`let x: i32 = 42`)
 
 ### 1.5 Boolean and Comparison Operations
 **Priority: 🔥 Critical**

--- a/include/ast.h
+++ b/include/ast.h
@@ -38,6 +38,7 @@ struct ASTNode {
             ASTNode* initializer;
             ASTNode* typeAnnotation;
             bool isConst;
+            bool isMutable;
         } varDecl;
         struct {
             char* name;

--- a/include/vm.h
+++ b/include/vm.h
@@ -370,6 +370,7 @@ typedef struct {
         char* name;
         uint8_t reg;  // Register allocation for local
         bool isActive;
+        bool isMutable;
     } locals[REGISTER_COUNT];
     int localCount;
     bool hadError;

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -133,6 +133,7 @@ int compileExpressionToRegister(ASTNode* node, Compiler* compiler) {
             compiler->locals[localIndex].name = node->varDecl.name;
             compiler->locals[localIndex].reg = (uint8_t)initReg;
             compiler->locals[localIndex].isActive = true;
+            compiler->locals[localIndex].isMutable = node->varDecl.isMutable;
             return initReg;
         }
         case NODE_ASSIGN: {
@@ -145,6 +146,10 @@ int compileExpressionToRegister(ASTNode* node, Compiler* compiler) {
                 }
             }
             if (localIndex < 0) return -1;
+            if (!compiler->locals[localIndex].isMutable) {
+                compiler->hadError = true;
+                return -1;
+            }
             uint8_t valueReg = compileExpressionToRegister(node->assign.value, compiler);
             if (valueReg < 0) return -1;
             emitByte(compiler, OP_MOVE);

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -190,6 +190,12 @@ static ASTNode* parseVariableDeclaration(void) {
         return NULL;
     }
 
+    bool isMutable = false;
+    if (peekToken().type == TOKEN_MUT) {
+        nextToken();
+        isMutable = true;
+    }
+
     Token nameToken = nextToken();
     if (nameToken.type != TOKEN_IDENTIFIER) {
         return NULL;
@@ -240,6 +246,7 @@ static ASTNode* parseVariableDeclaration(void) {
     varNode->varDecl.initializer = initializer;
     varNode->varDecl.typeAnnotation = typeNode;
     varNode->varDecl.isConst = false;
+    varNode->varDecl.isMutable = isMutable;
 
     return varNode;
 }
@@ -251,9 +258,42 @@ static ASTNode* parseExpression(void) { return parseAssignment(); }
 static ASTNode* parseAssignment(void) {
     ASTNode* left = parseBinaryExpression(0);
     if (!left) return NULL;
-    if (peekToken().type == TOKEN_EQUAL) {
+
+    TokenType t = peekToken().type;
+    if (t == TOKEN_EQUAL || t == TOKEN_PLUS_EQUAL || t == TOKEN_MINUS_EQUAL ||
+        t == TOKEN_STAR_EQUAL || t == TOKEN_SLASH_EQUAL) {
         nextToken();
-        ASTNode* value = parseBinaryExpression(0);
+        ASTNode* value = NULL;
+
+        if (t == TOKEN_EQUAL) {
+            value = parseBinaryExpression(0);
+        } else {
+            ASTNode* right = parseBinaryExpression(0);
+            if (!right) return NULL;
+            if (left->type != NODE_IDENTIFIER) return NULL;
+            ASTNode* binary = new_node();
+            binary->type = NODE_BINARY;
+            binary->binary.left = left;
+            binary->binary.right = right;
+            switch (t) {
+                case TOKEN_PLUS_EQUAL:
+                    binary->binary.op = "+";
+                    break;
+                case TOKEN_MINUS_EQUAL:
+                    binary->binary.op = "-";
+                    break;
+                case TOKEN_STAR_EQUAL:
+                    binary->binary.op = "*";
+                    break;
+                case TOKEN_SLASH_EQUAL:
+                    binary->binary.op = "/";
+                    break;
+                default:
+                    binary->binary.op = "+";
+                    break;
+            }
+            value = binary;
+        }
         if (!value || left->type != NODE_IDENTIFIER) return NULL;
         ASTNode* node = new_node();
         node->type = NODE_ASSIGN;
@@ -263,6 +303,7 @@ static ASTNode* parseAssignment(void) {
         node->dataType = NULL;
         return node;
     }
+
     return left;
 }
 

--- a/tests/assignment.orus
+++ b/tests/assignment.orus
@@ -1,3 +1,3 @@
-let x = 1
+let mut x = 1
 x = x + 2
 print(x)

--- a/tests/mut_compound.orus
+++ b/tests/mut_compound.orus
@@ -1,0 +1,4 @@
+let mut x: i32 = 5
+x += 3
+x *= 2
+print(x)


### PR DESCRIPTION
## Summary
- support `let mut` variables and type annotations in the parser
- add compound assignment parsing (`+=`, `-=`, etc.)
- prevent reassignment to immutable variables in the compiler
- document new variable features and update roadmap
- add tests covering mutable and compound assignments

## Testing
- `make all`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861c9f033e8832582f4c723ba77acc0