### PR TITLE
Implement dynamic vectors for loop jumps

### DIFF
--- a/docs/MISSING.md
+++ b/docs/MISSING.md
@@ -145,7 +145,8 @@ let result = x > 0 ? "positive" : "non-positive"
 - [x] **DONE**: While loop syntax parsing and basic compilation with condition hoisting
 - [x] **DONE**: For loop with range syntax (`0..5`, `0..=5`, `0..10..2`) and bounds checking
 - [ ] **DONE**: For loop with iterator syntax (`for item in collection`) with zero-copy iteration
-- [ ] Break and continue statements with proper scope handling and jump table optimization
+- [ ] Break and continue statements with proper scope handling and jump table optimization *(basic support implemented, dynamic jump table pending)*
+- [ ] Replace fixed-size break/continue jump arrays with dynamic vectors
 - [ ] Nested loop support with labeled break/continue for arbitrary loop depth
 - [ ] Loop variable scoping, lifetime management, and register allocation optimization
 - [ ] Compile-time infinite loop detection and runtime guard mechanisms
@@ -849,15 +850,15 @@ pub enum Result<T, E>
 ## 📝 Next Immediate Actions
 
 **Week 1 Priority:**
-- [ ] Fix string VALUE type conflicts in compiler
-- [ ] Implement variable assignment (`x = value`) parsing
-- [ ] Add boolean comparison operators (`==`, `!=`, `<`, `>`)
-- [ ] Test basic arithmetic with all data types
+- [x] Fix string VALUE type conflicts in compiler
+- [x] Implement variable assignment (`x = value`) parsing
+- [x] Add boolean comparison operators (`==`, `!=`, `<`, `>`)
+- [x] Test basic arithmetic with all data types
 
 **Week 2-4 Goals:**
-- [ ] Complete string concatenation and operations
-- [ ] Add if/else conditional statements
-- [ ] Implement while loops with break/continue
+- [x] Complete string concatenation and operations
+- [x] Add if/else conditional statements
+- [ ] Implement while loops with break/continue (label support pending)
 - [ ] Build comprehensive test suite for Phase 1 features
 
 This roadmap progresses systematically from basic language features to advanced capabilities, ensuring each phase builds solid foundations for the next. The register-based VM and existing infrastructure provide an excellent platform for rapid feature development.

--- a/include/intvec.h
+++ b/include/intvec.h
@@ -1,0 +1,38 @@
+#ifndef ORUS_INTVEC_H
+#define ORUS_INTVEC_H
+
+#include "memory.h"
+
+typedef struct {
+    int* data;
+    int count;
+    int capacity;
+} IntVec;
+
+static inline IntVec intvec_new() {
+    IntVec vec;
+    vec.data = NULL;
+    vec.count = 0;
+    vec.capacity = 0;
+    return vec;
+}
+
+static inline void intvec_free(IntVec* vec) {
+    if (vec->data) {
+        FREE_ARRAY(int, vec->data, vec->capacity);
+    }
+    vec->data = NULL;
+    vec->count = 0;
+    vec->capacity = 0;
+}
+
+static inline void intvec_push(IntVec* vec, int value) {
+    if (vec->capacity < vec->count + 1) {
+        int oldCapacity = vec->capacity;
+        vec->capacity = GROW_CAPACITY(oldCapacity);
+        vec->data = GROW_ARRAY(int, vec->data, oldCapacity, vec->capacity);
+    }
+    vec->data[vec->count++] = value;
+}
+
+#endif // ORUS_INTVEC_H

--- a/include/vm.h
+++ b/include/vm.h
@@ -362,11 +362,11 @@ typedef enum {
 } OpCode;
 
 // Loop context for break/continue statements
+#include "intvec.h"
+
 typedef struct {
-    int breakJumps[32];    // Array of break jump locations to patch
-    int breakCount;        // Number of break statements
-    int continueJumps[32]; // Array of continue jump locations to patch  
-    int continueCount;     // Number of continue statements
+    IntVec breakJumps;     // Patches for break statements
+    IntVec continueJumps;  // Jump targets for continue
     int continueTarget;    // Target for continue (loop start)
     int scopeDepth;        // Scope depth when loop was entered
 } LoopContext;


### PR DESCRIPTION
## Summary
- use a small `IntVec` dynamic vector helper
- convert `LoopContext` to store break/continue jumps in vectors
- update compiler loop handling to push jumps dynamically
- mark early roadmap tasks complete and note dynamic jump work in docs

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6862a5f4cdd48325ace14c8d7318e190